### PR TITLE
Simple CSS Fixes

### DIFF
--- a/radiant-player-mac/css/cocoa.css
+++ b/radiant-player-mac/css/cocoa.css
@@ -262,7 +262,7 @@
     background: none;
 }
 
-#player [data-id="now-playing-menu"] {
+#player:not(.material) [data-id="now-playing-menu"] {
     border: none;
 }
 

--- a/radiant-player-mac/css/dark-flat.css
+++ b/radiant-player-mac/css/dark-flat.css
@@ -289,7 +289,7 @@ a, .simple-dialog a {
     background: none;
 }
 
-#player [data-id="now-playing-menu"] {
+#player:not(.material) [data-id="now-playing-menu"] {
     border: none;
 }
 

--- a/radiant-player-mac/css/dark-yosemite.css
+++ b/radiant-player-mac/css/dark-yosemite.css
@@ -89,6 +89,10 @@
     text-align: left;
 }
 
+#gbqfq:focus::-webkit-input-placeholder {
+    opacity: 0;
+}
+
 .gm-nav-button {
     opacity: 1 !important;
     background-size: 12px 16px !important;

--- a/radiant-player-mac/css/dark.css
+++ b/radiant-player-mac/css/dark.css
@@ -300,7 +300,7 @@ a, .simple-dialog a {
     background: none;
 }
 
-#player [data-id="now-playing-menu"] {
+#player:not(.material) [data-id="now-playing-menu"] {
     border: none;
     background-color: transparent !important;
 }

--- a/radiant-player-mac/css/light.css
+++ b/radiant-player-mac/css/light.css
@@ -107,6 +107,10 @@ body {
     text-align: left;
 }
 
+#gbqfq:focus::-webkit-input-placeholder {
+    opacity: 0;
+}
+
 .gm-nav-button {
     border-radius: 3px;
     background-color: #fcfcfc;

--- a/radiant-player-mac/css/spotify-black-yosemite.css
+++ b/radiant-player-mac/css/spotify-black-yosemite.css
@@ -84,6 +84,10 @@
     text-align: left;
 }
 
+#gbqfq:focus::-webkit-input-placeholder {
+    opacity: 0;
+}
+
 .gm-nav-button {
     opacity: 1 !important;
     background-size: 12px 16px !important;

--- a/radiant-player-mac/css/spotify-black.css
+++ b/radiant-player-mac/css/spotify-black.css
@@ -10,7 +10,7 @@
  */
 
 #main, #content, #music-content {
-    background-color: #121314;
+    background-color: #121314 !important;
     color: #bbb;
 }
 
@@ -338,7 +338,7 @@ a, .simple-dialog a {
     background: none;
 }
 
-#player [data-id="now-playing-menu"] {
+#player:not(.material) [data-id="now-playing-menu"] {
     border: none;
 }
 

--- a/radiant-player-mac/css/yosemite.css
+++ b/radiant-player-mac/css/yosemite.css
@@ -275,7 +275,7 @@ body {
     background: none;
 }
 
-#player [data-id="now-playing-menu"] {
+#player:not(.material) [data-id="now-playing-menu"] {
     border: none;
 }
 


### PR DESCRIPTION
First off, love the app.  Really wish there was a windows version.  Onto business, I removed the border around the currently playing song menu.
![screen shot 2015-03-05 at 10 03 43](https://cloud.githubusercontent.com/assets/4356609/6511130/68cbcb14-c31f-11e4-82fd-efdb067a2771.png)
For the yosemite and light themes, when the user highlights the search bar the placeholder text now simply disappears instead of suddenly aligning left.  Lastly, the spotify-black theme main content area does not apply the background color, and as such looks like this:
![screen shot 2015-03-05 at 10 07 58](https://cloud.githubusercontent.com/assets/4356609/6511153/862c4b34-c31f-11e4-98d7-079224c73f6f.png)
In order to fix this, I added an !important to the background color (which worked for me).  Hopefully you find these changes useful.  Thanks again for the awesome app!
