### PR TITLE
Disabled dragging of file on to the webview

### DIFF
--- a/radiant-player-mac/WebView/CustomWebView.m
+++ b/radiant-player-mac/WebView/CustomWebView.m
@@ -144,6 +144,11 @@
     }
 }
 
+-(BOOL)performDragOperation:(id<NSDraggingInfo>)sender
+{
+    return false;
+}
+
 #pragma mark - Cookie code
 
 - (void)webView:(WebView *)sender resource:(id)identifier didReceiveResponse:(NSURLResponse *)response fromDataSource:(WebDataSource *)dataSource


### PR DESCRIPTION
This fix will prevent user from dragging pictures or other files on top of the WebView.
See also #284 