### PR TITLE
Color change for material menu anchor for the dark theme (fixes ##333)

### DIFF
--- a/radiant-player-mac/css/spotify-black.css
+++ b/radiant-player-mac/css/spotify-black.css
@@ -486,3 +486,7 @@ div.simple-dialog-bg {
 {
     background-image: url(https://radiant-player-mac/sprites-inverted.png) !important;
 }
+
+.material-card .details sj-icon-button.menu-anchor {
+    color: #fff;
+}


### PR DESCRIPTION
A simple CSS change to make the menu anchor buttons visible for the material cards. Fixes #333.

Before:
![screenshot 2015-06-05 20 58 46](https://cloud.githubusercontent.com/assets/1739462/8017512/98acd0e6-0bc5-11e5-83a4-11ff762f4ff3.png)

After:
![screenshot 2015-06-05 20 58 06](https://cloud.githubusercontent.com/assets/1739462/8017515/9eefbf2c-0bc5-11e5-8e10-ccd62866dc83.png)
