### PR TITLE
Replace both webcomponents.js and webcomponents.min.js with fallback

### DIFF
--- a/radiant-player-mac/WebView/CustomWebView.m
+++ b/radiant-player-mac/WebView/CustomWebView.m
@@ -118,7 +118,8 @@
         [self handleCookiesForRequest:req redirectResponse:redirectResponse];
         
         // The WebComponents library that was buggy!
-        if ([[url lastPathComponent] isEqualToString:@"webcomponents.js"])
+        NSString *fileName = [url lastPathComponent];
+        if ([fileName isEqualToString:@"webcomponents.js"] || [fileName isEqualToString:@"webcomponents.min.js"])
         {
             [NSURLProtocol setProperty:self forKey:@"WebComponentsCustomWebView" inRequest:req];
         }


### PR DESCRIPTION
Google renamed `webcomponents.js` to `webcomponents.min.js` which broke the custom substitution.  This fixes that by replacing either filename.

Fixes #351.